### PR TITLE
memory usage cleanup

### DIFF
--- a/source/arm7/wifi_arm7.c
+++ b/source/arm7/wifi_arm7.c
@@ -851,14 +851,6 @@ void Wifi_Update() {
 //
 //  Wifi User-called Functions
 //
-void erasemem(void * mem, int length) {
-	int i;
-	char * m = (char *)mem;
-	for(i=0;i<length;i++)
-		m[i]=0;
-}
-
-
 void Wifi_Init(u32 wifidata) {
 	WifiData = (Wifi_MainStruct *)wifidata;
 

--- a/source/arm7/wifi_arm7.c
+++ b/source/arm7/wifi_arm7.c
@@ -854,14 +854,13 @@ void Wifi_Update() {
 void Wifi_Init(u32 wifidata) {
 	WifiData = (Wifi_MainStruct *)wifidata;
 
-#define REG_GPIOWTF (*(vu16*)0x4004C04)
-	if (isDSiMode() & !(REG_GPIOWTF & BIT(8))) {
-		REG_GPIOWTF = (REG_GPIOWTF&1) | BIT(8);
-		swiDelay(0xA3A47); //5ms
-	}
+	// Initialize NTR WiFi on DSi.
+	gpioSetWifiMode(GPIO_WIFI_MODE_NTR);
+	if (REG_GPIO_WIFI)
+		swiDelay(5/*ms*/ * 134056);
 
 	POWERCNT7 |= 2; // enable power for the wifi
-	*((volatile u16 *)0x04000206) = 0x30; // ???
+	WIFIWAITCNT = WIFI_RAM_N_10_CYCLES | WIFI_RAM_S_6_CYCLES | WIFI_IO_N_6_CYCLES | WIFI_IO_S_4_CYCLES;
 
 	InitFlashData();
 

--- a/source/arm9/sgIP_DNS.h
+++ b/source/arm9/sgIP_DNS.h
@@ -12,6 +12,7 @@
 #define SGIP_DNS_FLAG_ACTIVE     1
 #define SGIP_DNS_FLAG_RESOLVED   2
 #define SGIP_DNS_FLAG_BUSY       4
+#define SGIP_DNS_FLAG_PERMANENT  8
 
 typedef struct SGIP_DNS_RECORD {
    char              name [256];
@@ -20,7 +21,7 @@ typedef struct SGIP_DNS_RECORD {
    short             addrlen;
    short             addrclass;
    int               numaddr,numalias;
-   int               TTL;
+   int               expiry_time_count;
    int               flags;
 } sgIP_DNS_Record;
 
@@ -40,7 +41,7 @@ extern void sgIP_DNS_Init();
 extern void sgIP_DNS_Timer1000ms();
 
 extern sgIP_DNS_Hostent * sgIP_DNS_gethostbyname(const char * name);
-extern sgIP_DNS_Record  * sgIP_DNS_GetUnusedRecord();
+extern sgIP_DNS_Record  * sgIP_DNS_AllocUnusedRecord();
 extern sgIP_DNS_Record  * sgIP_DNS_FindDNSRecord(const char * name);
 
 #ifdef __cplusplus

--- a/source/arm9/wifi_arm9.c
+++ b/source/arm9/wifi_arm9.c
@@ -226,9 +226,7 @@ void ethhdr_print(char f, void * d) {
 }
 
 
-
-
-Wifi_MainStruct Wifi_Data_Struct;
+Wifi_MainStruct *Wifi_Data_Struct = NULL;
 
 volatile Wifi_MainStruct * WifiData = 0;
 
@@ -769,9 +767,15 @@ void Wifi_Timer(int num_ms) {
 #endif
 
 unsigned long Wifi_Init(int initflags) {
-	memset(&Wifi_Data_Struct,0,sizeof(Wifi_Data_Struct));
+	if (Wifi_Data_Struct == NULL) {
+		Wifi_Data_Struct = malloc(sizeof(Wifi_MainStruct));
+		if (Wifi_Data_Struct == NULL) {
+			return 0;
+		}
+	}
+	memset(Wifi_Data_Struct,0,sizeof(Wifi_MainStruct));
     DC_FlushAll();
-	WifiData = (Wifi_MainStruct *) memUncached(&Wifi_Data_Struct); // should prevent the cache from eating us alive.
+	WifiData = (Wifi_MainStruct *) memUncached(Wifi_Data_Struct); // should prevent the cache from eating us alive.
 
 #ifdef WIFI_USE_TCP_SGIP
     switch(initflags & WIFIINIT_OPTION_HEAPMASK) {
@@ -795,7 +799,7 @@ unsigned long Wifi_Init(int initflags) {
 #endif
     
 	WifiData->flags9 = WFLAG_ARM9_ACTIVE | (initflags & WFLAG_ARM9_INITFLAGMASK) ;
-	return (u32) &Wifi_Data_Struct;
+	return (u32) Wifi_Data_Struct;
 }
 
 int Wifi_CheckInit() {

--- a/source/arm9/wifi_arm9.c
+++ b/source/arm9/wifi_arm9.c
@@ -235,13 +235,6 @@ volatile Wifi_MainStruct * WifiData = 0;
 WifiPacketHandler packethandler = 0;
 WifiSyncHandler synchandler = 0;
 
-void erasemem(void * mem, int length) {
-	int i;
-	char * m = (char *)mem;
-	for(i=0;i<length;i++)
-		m[i]=0;
-}
-
 void Wifi_CopyMacAddr(volatile void * dest, volatile void * src) {
 	((u16 *)dest)[0]=((u16 *)src)[0];
 	((u16 *)dest)[1]=((u16 *)src)[1];
@@ -777,7 +770,7 @@ void Wifi_Timer(int num_ms) {
 #endif
 
 unsigned long Wifi_Init(int initflags) {
-	erasemem(&Wifi_Data_Struct,sizeof(Wifi_Data_Struct));
+	memset(&Wifi_Data_Struct,0,sizeof(Wifi_Data_Struct));
     DC_FlushAll();
 	WifiData = (Wifi_MainStruct *) memUncached(&Wifi_Data_Struct); // should prevent the cache from eating us alive.
 

--- a/source/arm9/wifi_arm9.c
+++ b/source/arm9/wifi_arm9.c
@@ -472,8 +472,8 @@ void sgIP_DNS_Record_Localhost()
 {
     sgIP_DNS_Record *rec;
     const unsigned char * resdata_c = (unsigned char *)&(wifi_hw->ipaddr);
-    rec = sgIP_DNS_GetUnusedRecord();
-    rec->flags=SGIP_DNS_FLAG_ACTIVE | SGIP_DNS_FLAG_BUSY;
+    rec = sgIP_DNS_AllocUnusedRecord();
+    rec->flags=SGIP_DNS_FLAG_ACTIVE | SGIP_DNS_FLAG_BUSY | SGIP_DNS_FLAG_PERMANENT;
     
     rec->addrlen    = 4;
     rec->numalias   = 1;
@@ -485,9 +485,8 @@ void sgIP_DNS_Record_Localhost()
     rec->addrdata[2] = resdata_c[2];
     rec->addrdata[3] = resdata_c[3];
     rec->addrclass = AF_INET;
-    rec->TTL = 0;
 
-    rec->flags=SGIP_DNS_FLAG_ACTIVE | SGIP_DNS_FLAG_BUSY|SGIP_DNS_FLAG_RESOLVED;
+    rec->flags=SGIP_DNS_FLAG_ACTIVE | SGIP_DNS_FLAG_BUSY | SGIP_DNS_FLAG_RESOLVED | SGIP_DNS_FLAG_PERMANENT;
 }
 
 int Wifi_AssocStatus() {


### PR DESCRIPTION
Fixes https://github.com/blocksds/sdk/issues/56 to a satisfactory level for now. This also ensures the GPIO write to switch to NDS-mode Wi-Fi is always performed in NDS mode - it should never be necessary then, but you *can* officially perform it in NDS mode, so it won't hurt to do so.

I'm not sure if I'll be working on dswifi more, but I wanted to at least briefly examine its code quality.