### PR TITLE
Change dswifi_version.h from a build artifact to a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 build/
-include/dswifi_version.h
 lib/
 docs/
 warn.log

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ DSWIFI_MAJOR	:= 0
 DSWIFI_MINOR	:= 4
 DSWIFI_REVISION	:= 2
 VERSION		:= $(DSWIFI_MAJOR).$(DSWIFI_MINOR).$(DSWIFI_REVISION)
-VERSION_HEADER	:= include/dswifi_version.h
 
 # Tools
 # -----
@@ -33,19 +32,7 @@ endif
 
 .PHONY: all arm7 arm9 clean docs install
 
-all: $(VERSION_HEADER) arm9 arm7
-
-$(VERSION_HEADER): Makefile
-	@echo "#ifndef _dswifi_version_h_" > $@
-	@echo "#define _dswifi_version_h_" >> $@
-	@echo >> $@
-	@echo "#define DSWIFI_MAJOR    $(DSWIFI_MAJOR)" >> $@
-	@echo "#define DSWIFI_MINOR    $(DSWIFI_MINOR)" >> $@
-	@echo "#define DSWIFI_REVISION $(DSWIFI_REVISION)" >> $@
-	@echo >> $@
-	@echo '#define DSWIFI_VERSION "'$(DSWIFI_MAJOR).$(DSWIFI_MINOR).$(DSWIFI_REVISION)'"' >> $@
-	@echo >> $@
-	@echo "#endif // _dswifi_version_h_" >> $@
+all: arm9 arm7
 
 arm9:
 	@+$(MAKE) -f Makefile.arm9 --no-print-directory
@@ -57,7 +44,7 @@ arm7:
 
 clean:
 	@echo "  CLEAN"
-	@$(RM) $(VERSION_HEADER) lib build
+	@$(RM) lib build
 
 docs:
 	@echo "  DOXYGEN"

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,6 @@
 #
 # SPDX-FileContributor: Antonio Niño Díaz, 2023
 
-# Defines
-# -------
-
-DSWIFI_MAJOR	:= 0
-DSWIFI_MINOR	:= 4
-DSWIFI_REVISION	:= 2
-VERSION		:= $(DSWIFI_MAJOR).$(DSWIFI_MINOR).$(DSWIFI_REVISION)
-
 # Tools
 # -----
 

--- a/include/dswifi_version.h
+++ b/include/dswifi_version.h
@@ -1,0 +1,10 @@
+#ifndef _dswifi_version_h_
+#define _dswifi_version_h_
+
+#define DSWIFI_MAJOR    0
+#define DSWIFI_MINOR    4
+#define DSWIFI_REVISION 2
+
+#define DSWIFI_VERSION (DSWIFI_MAJOR "." DSWIFI_MINOR "." DSWIFI_REVISION)
+
+#endif


### PR DESCRIPTION
`dswifi7.h` and `dswifi9.h` require `dswifi_version.h`, a build artifact, to be present in the same include directory. This makes self-contained builds impossible without patches as the header cannot be generated in a build directory. Primary motivation for this patch is [zig-nds](https://github.com/GalaxyShard/zig-nds/)

There are a few alternative solutions, e.g. the #includes could be changed from `#include "dswifi_version.h"` to `#include <dswifi_version.h>`, this was just a solution I thought of that shouldn't affect backwards compatibility.